### PR TITLE
Add Content Security Policy and reorder favicon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/assets/icon-vortex.png" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Global Vortex Solutions - Soluções empresariais inovadoras em tecnologia, análise de dados e transformação digital para empresas de todos os portes." />
     <meta name="keywords" content="Global Vortex, tecnologia empresarial, soluções digitais, consultoria de TI, transformação digital" />
@@ -12,6 +12,7 @@
     <meta property="og:image" content="/assets/og-image.jpg" />
     <meta property="og:url" content="https://globalvortexs.com" />
     <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="/assets/icon-vortex.png" />
     <title>Global Vortex Solutions | Tecnologia & Inovação</title>
   </head>
   <body class="h-full min-h-screen">


### PR DESCRIPTION
This pull request makes a minor adjustment to the order of elements in the `index.html` file. The most notable change is moving the favicon link below the meta tags and adding a Content Security Policy header for improved security.

Security and meta tag improvements:

* Added a Content Security Policy meta tag (`http-equiv="Content-Security-Policy"`) to restrict resource loading to the same origin.
* Moved the favicon link (`icon-vortex.png`) to appear after the meta tags, improving the structure and organization of the HTML head section.