### PR TITLE
fix: Update Content Security Policy to enhance security and allow specific resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.iconify.design https://api.unisvg.com https://api.simplesvg.com; img-src 'self' data: https:;">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Global Vortex Solutions - Soluções empresariais inovadoras em tecnologia, análise de dados e transformação digital para empresas de todos os portes." />
     <meta name="keywords" content="Global Vortex, tecnologia empresarial, soluções digitais, consultoria de TI, transformação digital" />


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in the `index.html` file to allow resources from specific external sources. The changes expand the policy to permit scripts, styles, fonts, connections, and images from trusted third-party domains, which is necessary for integrating external libraries and APIs.

Security and resource integration:

* Updated the CSP meta tag in `index.html` to allow inline scripts and styles, and to permit loading resources from trusted external domains for scripts (`cdn.jsdelivr.net`), styles (`fonts.googleapis.com`), fonts (`fonts.gstatic.com`), API connections (`iconify.design`, `unisvg.com`, `simplesvg.com`), and images (data URLs and HTTPS).